### PR TITLE
Build script

### DIFF
--- a/lib/install/esbuild.js
+++ b/lib/install/esbuild.js
@@ -1,0 +1,15 @@
+const watch = process.argv.includes("--watch") && {
+  onRebuild(error) {
+    if (error) console.error("[watch] build failed", error);
+    else console.log("[watch] build finished");
+  },
+};
+
+require("esbuild")
+  .build({
+    entryPoints: ["app/javascript/application.js"],
+    bundle: true,
+    outfile: "app/assets/esbuilds/application.js",
+    watch: watch,
+  })
+  .catch(() => process.exit(1));

--- a/lib/install/install.rb
+++ b/lib/install/install.rb
@@ -9,7 +9,7 @@ end
 
 if (app_layout_path = Rails.root.join("app/views/layouts/application.html.erb")).exist?
   say "Add esbuild include tag in application layout"
-  insert_into_file app_layout_path.to_s, 
+  insert_into_file app_layout_path.to_s,
     %(\n    <%= javascript_include_tag "application", "data-track-turbo": "true", defer: true %>), before: /\s*<\/head>/
 else
   say "Default application.html.erb is missing!", :red
@@ -23,5 +23,6 @@ unless (app_js_entrypoint_path = Rails.root.join("app/javascript/application.js"
 end
 
 say "Create default package.json and install esbuild"
+copy_file "#{__dir__}/esbuild.js", Rails.root.join("app/assets/config/esbuild.js")
 copy_file "#{__dir__}/package.json", "package.json"
 run "yarn add esbuild"

--- a/lib/install/package.json
+++ b/lib/install/package.json
@@ -2,6 +2,6 @@
   "name": "myapp",
   "private": "true",
   "scripts": {
-    "build": "esbuild app/javascript/application.js  --outfile=app/assets/esbuilds/application.js --bundle"
+    "build": "node app/assets/config/esbuild.js"
   }
 }


### PR DESCRIPTION
The default setup works great, even for React and JSX! That said, I think having the default build script mentioned in #1 would be a huge boost.

I've attempted to add a build script during the install process. To be clear, here- I'm very new to esbuild, so if there is a better way to do any of the things here I'm glad to change it! 

* Adds a build script: `app/assets/config/esbuild.js` 
* Changes the `package.json` build command to use the new script
    * I'm using the node command here, but it might be better as an executable. If someone could help me know what permissions to use for the executable I'd be glad to make that happen.
* Turns on "watch" mode if `--watch` is one of the arguments passed to the build script 
    * I lost the output when a build happens using watch mode, so I used the `onRebuild` function mentioned in the [esbuild docs](https://esbuild.github.io/api/#watch)
    * I'm not overly enthusiastic about the overhead of reading the arguments and defining this function, but I do think having some type of feedback when a build occurs is valuable